### PR TITLE
Update docker image to add metalinter and ssl

### DIFF
--- a/images/golang.dockerfile
+++ b/images/golang.dockerfile
@@ -1,8 +1,12 @@
 FROM golang:alpine
 
 RUN apk update && \
-    apk add git && \
+    apk add git openssl && \
     adduser -S moolinet
+
+RUN go get -u github.com/alecthomas/gometalinter && \
+    gometalinter --install && \
+    chmod -R 777 /go
 
 COPY ./moolinet-write /usr/bin
 


### PR DESCRIPTION
We issue a chmod to allow moolinet user to install packages in
$GOPATH/bin.